### PR TITLE
docs: correct directory

### DIFF
--- a/resources/GET_STARTED.md
+++ b/resources/GET_STARTED.md
@@ -42,7 +42,7 @@ The `git clone` command copies your repository from GitHub to your local compute
 
 ```sh
 cd 02-ui-library
-cd 02-ui-library-task-template
+cd ui-library-task-template
 ```
 
 * Run `yarn` to fetch all packages and dependencies.


### PR DESCRIPTION
Correct directory in line 45 is "ui-library-task-template" not "cd 02-ui-library-task-template" hence cd 02-ui-library\ui-library-task-template exists whereas cd 02-ui-library\02-ui-library-task-template, doesn't exist. Thank you! (: