### PR TITLE
docs: update yarn command line 61

### DIFF
--- a/resources/GET_STARTED.md
+++ b/resources/GET_STARTED.md
@@ -55,10 +55,10 @@ You are now ready to start your application locally!
 
 ### Start your DHIS2 application locally 
 
-* Run `yarn start` - This will run the app in the development mode.
+* Run `yarn run start` - This will run the app in the development mode.
 
 ```sh
-yarn start 
+yarn run start 
 ```
 
 * From the browser, go to [http://localhost:3000](http://localhost:3000). You will see the following page: 


### PR DESCRIPTION
Using yarn start no longer works and instead the command that does the same function is yarn run start. When using yarn start, one gets this error: [ERROR] Start script exited with non-zero exit code 
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.