### PR TITLE
docs: proper key to get indicator name

### DIFF
--- a/workshop-1/04-app-runtime/query/src/IndicatorsList.js
+++ b/workshop-1/04-app-runtime/query/src/IndicatorsList.js
@@ -23,7 +23,7 @@ export const IndicatorsList = () => {
     return <ul className={classes.list}>
         {data.results.indicators.map(indicator =>
             <li>
-                <strong>{indicator.name}</strong><br/>
+                <strong>{indicator.displayName}</strong><br/>
                 <span>{indicator.description}</span>
             </li>
         )}


### PR DESCRIPTION
In line 26 when using indicator.name no results appear but using indicator.displayName fixes the issue since the key in the result from the query is "displayName" not "name" and in the https://runtime.dhis2.nu/#/hooks/useDataQuery example too! Thanks!